### PR TITLE
Add a more reliable check for a hotfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY lib/semver.sh ./lib/semver
 RUN install ./lib/semver /usr/local/bin
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apk add --no-cache bash git
+RUN apk add --no-cache bash git jq
+RUN apk add --no-cache hub --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,29 +63,12 @@ get_bump_level_from_git_commit_messages() {
   echo ${bump_level}
 }
 
-check_is_hotfix() {
-  local previous_commit
-  local branch_list
-  local number_of_branches
-
-  # get ancestor commit.
-  previous_commit=$(git rev-parse "${GITHUB_SHA}"^1) || return 1
-  # get list of branches (from remote) that contain the ancestor commit
-  branch_list=$(git branch --contains="${previous_commit}" -r) || return 1
-  # count new lines to get number of branches
-  number_of_branches=$(wc -l <<< "${branch_list}") || return 1
-  # trim whitespace returned from wc command
-  number_of_branches=$(echo -n "${number_of_branches//[[:space:]]/}")
-
-  # if there are exactly two branches, one of which is a "hotfix" branch and the other is the current branch
-  # then this is considered a hotfix
-  if [[ number_of_branches -eq "2" ]] && [[ ${branch_list}==*"hotfix/"* ]] && [[ ${branch_list}==*"${branch_name}"* ]]; then
-    echo true
+is_hotfix() {
+  source_branch=$(hub api /repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls -H "accept: application/vnd.github.groot-preview+json" | jq .[0].head.label)
+  if [[ ${source_branch} == *"hotfix/"* ]]; then
     return 0
   fi
-
-  echo false
-  return 0
+  return 1
 }
 
 move_previous_tag() {
@@ -131,9 +114,7 @@ fi
 echo "Previous version tag: ${previous_version_tag:-"Not found"}"
 
 # Perform check do determine if this was triggered by a hotfix
-is_hotfix=$(check_is_hotfix) || die "failed to check if hotfix"
-
-if [ "${is_hotfix}" == false ]; then
+if is_hotfix; then
     # Get version bump level from previous commit messages
     bump_level=$(get_bump_level_from_git_commit_messages ${previous_version_tag}) || die "Failed to retrieve commit messages since previous tag"
     echo "Version bump level: ${bump_level}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,19 +115,19 @@ echo "Previous version tag: ${previous_version_tag:-"Not found"}"
 
 # Perform check do determine if this was triggered by a hotfix
 if is_hotfix; then
-    # Get version bump level from previous commit messages
-    bump_level=$(get_bump_level_from_git_commit_messages ${previous_version_tag}) || die "Failed to retrieve commit messages since previous tag"
-    echo "Version bump level: ${bump_level}"
-
-    # Bump the version number
-    new_version=$(semver bump ${bump_level} ${previous_version}) || die "Failed to bump the ${bump_level} version of ${previous_version}"
-    new_version_tag=${version_tag_prefix}${new_version}
-    tag_message="Bump ${branch_name} tag from ${previous_version_tag} to ${new_version_tag}"
-else
   echo "Hotfix detected. Moving previous version tag to current latest on ${branch_name}"
   # move_previous_tag "${previous_version_tag}" "${GITHUB_SHA}" || die "Failed to move tag for hotfix"
   new_version_tag=${previous_version_tag}
   tag_message="Apply hotfix, moving ${previous_version_tag} to latest ${branch_name}"
+else
+  # Get version bump level from previous commit messages
+  bump_level=$(get_bump_level_from_git_commit_messages ${previous_version_tag}) || die "Failed to retrieve commit messages since previous tag"
+  echo "Version bump level: ${bump_level}"
+
+  # Bump the version number
+  new_version=$(semver bump ${bump_level} ${previous_version}) || die "Failed to bump the ${bump_level} version of ${previous_version}"
+  new_version_tag=${version_tag_prefix}${new_version}
+  tag_message="Bump ${branch_name} tag from ${previous_version_tag} to ${new_version_tag}"
 fi
 # Add prefix to new version to create the new tag
 


### PR DESCRIPTION

Retrieves the pull request related to the current commit and checks the
source branch name for "hotfix/"

This should be more reliable than the previous method of checking for a hotfix